### PR TITLE
Make SSL policy configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ for more details.
 |health_check_healthy_threshold| The number of successful health checks before an instance is put into service	|10| no|
 |listener_port| Port that ALB listens on|443| no|
 |listener_protocol| Protocol that the ALB listens on|HTTPS| no|
+|listener_ssl_policy| SSL policy for the ALB |ELBSecurityPolicy-2016-08| no|
 |listener_certificate_arn|certificate ARN to be used by the certificate|-| yes|
 
 ### Outputs

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -46,6 +46,7 @@ health_check_interval: 30
 
 listener_port: 443
 listener_protocol: 'HTTPS'
+listener_ssl_policy: 'ELBSecurityPolicy-TLS-1-2-Ext-2018-06'
 
 security_groups:
   default:
@@ -84,6 +85,7 @@ listeners:
   - key: "default"
     port: "%{hiera('listener_port')}"
     protocol: "%{hiera('listener_protocol')}"
+    ssl_policy: "%{hiera('listener_ssl_policy')}"
     default_action:
       type: "forward"
       target_group_key: "default"

--- a/listener.tf
+++ b/listener.tf
@@ -6,7 +6,7 @@ resource "aws_lb_listener" "listener" {
   port = each.value.port
   protocol = each.value.protocol
 
-  //  ssl_policy = "ELBSecurityPolicy-2016-08"
+  ssl_policy = each.value.ssl_policy
   certificate_arn = each.value.certificate_arn
 
   default_action {

--- a/locals.tf
+++ b/locals.tf
@@ -45,6 +45,7 @@ locals {
       port = lookup(listener, "port", 443),
       protocol = lookup(listener, "protocol", "HTTPS"),
       certificate_arn = listener.certificate_arn,
+      ssl_policy = lookup(listener, "ssl_policy", "ELBSecurityPolicy-2016-08"),
       default_action = {
         type = lookup(listener.default_action, "type", "forward"),
         target_group_key = lookup(listener.default_action, "target_group_key", null),

--- a/spec/infra/harness/main.tf
+++ b/spec/infra/harness/main.tf
@@ -12,6 +12,7 @@ locals {
       key = listener.key
       port = listener.port,
       protocol: listener.protocol,
+      ssl_policy: listener.ssl_policy
       certificate_arn: data.terraform_remote_state.prerequisites.outputs.certificate_arn,
       default_action: listener.default_action
     }

--- a/spec/infra/harness/variables.tf
+++ b/spec/infra/harness/variables.tf
@@ -54,6 +54,7 @@ variable "listeners" {
     key: string,
     port: string,
     protocol: string,
+    ssl_policy: string,
     default_action: object({
       type: string,
       target_group_key: string

--- a/spec/listeners_spec.rb
+++ b/spec/listeners_spec.rb
@@ -15,6 +15,8 @@ describe 'Listener' do
   }
   its(:protocol) {should eq vars.listeners[0]["protocol"]}
 
+  its(:ssl_policy) {should eq vars.listeners[0]["ssl_policy"]}
+
   it 'uses the provided certificate' do
     certificates = subject.certificates
 

--- a/variables.tf
+++ b/variables.tf
@@ -101,6 +101,7 @@ variable "listeners" {
     port: string,
     protocol: string,
     certificate_arn: string,
+    ssl_policy: string,
     default_action: object({
       type: string,
       target_group_key: string


### PR DESCRIPTION
Make ssl policy configurable. It is optional to pass this and the default value is "ELBSecurityPolicy-2016-08" (the same one AWS assigns by default). 

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener#ssl_policy

I ran the tests but I was getting this error without the changes:

`Error: 1 error occurred:
	* missing greasedscone.uk DNS validation record: _30376f5d458ae66a3932f6c3a2530aac.greasedscone.uk`

Might be some issue with the private_zone_id and public_zone_id I configured.